### PR TITLE
Fix multiple definitions error caused by lack of VESUVIUS_IMPL guard in original vesuvius-c code

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ gcc -o example example.c -I/opt/homebrew/Cellar/c-blosc2/2.15.1/include -L/opt/h
 ./example
 ```
 
+It may also be necessary to link with the system math library:
+
+```sh
+gcc -o example example.c -lcurl -lblosc2 -ljson-c -lm
+./example
+```
+
 ## Next features
 
 * Reading scroll segments (`.obj` mesh files)

--- a/example.c
+++ b/example.c
@@ -1,3 +1,4 @@
+#define VESUVIUS_IMPL
 #include "vesuvius-c.h"
 #include <stdio.h>
 

--- a/vesuvius-c.h
+++ b/vesuvius-c.h
@@ -8,23 +8,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
-#include <json-c/json.h>
+#include <json.h>
 #include <blosc2.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <errno.h>
 #include <float.h>
 
-// Variables to hold Zarr's chunk sizes and shape, initially set to -1 to indicate uninitialized
-int CHUNK_SIZE_X = -1, CHUNK_SIZE_Y = -1, CHUNK_SIZE_Z = -1;
-int SHAPE_X = -1, SHAPE_Y = -1, SHAPE_Z = -1;
-
 // Buffer size for metadata JSON and URL
 #define BUFFER_SIZE 4096
 #define URL_SIZE 256
-
-// Global variable to store the dynamically constructed Zarr URL
-char ZARR_URL[URL_SIZE] = {0};  // Initially empty
 
 #define CACHE_CAPACITY 100  // Define the LRU cache capacity
 #define CACHE_DIR ".vesuvius-cache"
@@ -113,8 +106,17 @@ int write_trianglemesh_to_obj(const char *filename, const TriangleMesh *mesh);
 RegionOfInterest get_mesh_bounding_box(const TriangleMesh *mesh);
 void reset_mesh_origin_to_roi(TriangleMesh *mesh, const RegionOfInterest *roi);
 
+#ifdef VESUVIUS_IMPL
+
 // Global cache
 LRUCache *cache;
+
+// Global variable to store the dynamically constructed Zarr URL
+char ZARR_URL[URL_SIZE] = {0};  // Initially empty
+
+// Variables to hold Zarr's chunk sizes and shape, initially set to -1 to indicate uninitialized
+int CHUNK_SIZE_X = -1, CHUNK_SIZE_Y = -1, CHUNK_SIZE_Z = -1;
+int SHAPE_X = -1, SHAPE_Y = -1, SHAPE_Z = -1;
 
 // Internal function to write data fetched by cURL
 static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *stream) {
@@ -928,6 +930,7 @@ void reset_mesh_origin_to_roi(TriangleMesh *mesh, const RegionOfInterest *roi) {
     }
 }
 
+#endif
 
 //vesuvius notes:
 // - when passing pointers to a _new function in order to fill out fields in the struct (e.g. vs_mesh_new)

--- a/vesuvius-c.h
+++ b/vesuvius-c.h
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
-#include <json.h>
+#include <json-c/json.h>
 #include <blosc2.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
The code I did not commit wasn't guarded by the VESUVIUS_IMPL guard. This can cause issues when compiling multiple .c files together where the other code would get multiple function definition errors during linking. 

I also tacked on a bit more info for the readme. At least for me, if I don't link with the system math library then I get link errors when trying to use `sqrtf`. Dunno where that's used, but I guess it is used.